### PR TITLE
Change Google Play Music to Google Podcasts

### DIFF
--- a/src/site/_data/site.json
+++ b/src/site/_data/site.json
@@ -12,7 +12,7 @@
   "facebook_id": "1018260045",
   "itunes_url": "https://podcasts.apple.com/us/podcast/on-the-metal/id1488187473",
   "android_url": "https://www.google.com/podcasts?feed=aHR0cHM6Ly9mZWVkcy50cmFuc2lzdG9yLmZtL29uLXRoZS1tZXRhbC0wMjk0NjQ5ZS1lYzIzLTRlYWItOTc1YS05ZWIxM2ZkOTRlMDY%3D",
-  "google_play_url": "https://play.google.com/music/m/Iycdfnasjwyvpe7ona6zwjwhkr4?t=On_The_Metal",
+  "google_podcasts_url": "https://podcasts.google.com/feed/aHR0cHM6Ly9mZWVkcy50cmFuc2lzdG9yLmZtL29uLXRoZS1tZXRhbC0wMjk0NjQ5ZS1lYzIzLTRlYWItOTc1YS05ZWIxM2ZkOTRlMDY=",
   "stitcher_url": "https://www.stitcher.com/s?fid=488658&refid=stpr",
   "pocketcasts_url": "https://pca.st/gg2yq8h0",
   "spotify_url": "https://open.spotify.com/show/4GDUravTUbvTrdJ2oWnzJp",

--- a/src/site/_includes/components/podcast-share.njk
+++ b/src/site/_includes/components/podcast-share.njk
@@ -13,12 +13,12 @@
     </svg>
     <span>Android</span>
   </a>
-  <a href="{{ site.google_play_url }}" target="_blank" rel="noopener">
+  <a href="{{ site.google_podcasts_url }}" target="_blank" rel="noopener">
     <svg aria-hidden="true" data-icon="google-play" viewBox="0 0 512 512" class="podcast-icon" xmlns="http://www.w3.org/2000/svg">
       <title>Google Play icon</title>
       <path fill="currentColor" d="M325.3 234.3L104.6 13l280.8 161.2-60.1 60.1zM47 0C34 6.8 25.3 19.2 25.3 35.3v441.3c0 16.1 8.7 28.5 21.7 35.3l256.6-256L47 0zm425.2 225.6l-58.9-34.1-65.7 64.5 65.7 64.5 60.1-34.1c18-14.3 18-46.5-1.2-60.8zM104.6 499l280.8-161.2-60.1-60.1L104.6 499z"/>
     </svg>
-    <span>Google Play Music</span>
+    <span>Google Podcasts</span>
   </a>
   {%- if site.stitcher_url -%}
     <a href="{{ site.stitcher_url }}" target="_blank" rel="noopener">


### PR DESCRIPTION
Google Play Music was discontinued last year so Google Podcasts is probably a better link now.