### PR TITLE
Fix contrast ratio on selection

### DIFF
--- a/src/site/_includes/css/tailwind.css
+++ b/src/site/_includes/css/tailwind.css
@@ -175,11 +175,13 @@ html::-webkit-scrollbar-thumb {
 
 ::selection {
     background: #b2edd3;
+    @apply text-oxide-gray;
     /* WebKit/Blink Browsers */
 }
 
 ::-moz-selection {
     background: #b2edd3;
+    @apply text-oxide-gray;
     /* Gecko Browsers */
 }
 


### PR DESCRIPTION
Original:
![image](https://user-images.githubusercontent.com/6877780/110057205-3240b080-7d2e-11eb-8bd2-cee6485291f7.png)

Fixed:
![image](https://user-images.githubusercontent.com/6877780/110057227-38369180-7d2e-11eb-9b84-24f589a2df51.png)

Something else of note. While I was doing this, I considered that we may want to keep the original color in cases where it makes sense, but upon further investigation, it seems many sites don't bother, so I don't think users will be put off by it:
![image](https://user-images.githubusercontent.com/6877780/110057623-e8a49580-7d2e-11eb-82c3-6adcd94140d6.png)
